### PR TITLE
chore: simplify authentication

### DIFF
--- a/security_overlay.yml
+++ b/security_overlay.yml
@@ -7,17 +7,11 @@ actions:
     update:
       security:
         - bearerAuth: []
-        - bearerAuth: []
-          namespace: []
   - target: $["components"]
     update:
       securitySchemes:
         bearerAuth:
           type: http
           scheme: bearer
-        namespace:
-          type: apiKey
-          in: header
-          name: x-namespace
   - target: $["components"]["schemas"]
     remove: true


### PR DESCRIPTION
- Adding the header for `x-namespace` into security is redundant as its already defined as a header parameter in every operation on the spec